### PR TITLE
Simple fix for deprecated warning:

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@
 #------------------------------------------------------------------------------
 variable "efs_name" {
   description = "The name of the Elastic File System"
-  type        = "string"
+  type        = string
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
Warning: Quoted type constraints are deprecated

  on .terraform/modules/efs-0/variables.tf line 6, in variable "efs_name":
   6:   type        = "string"